### PR TITLE
add dns-route53 plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ $ juju run-action --wait certbot/0 get-dns-google-certificate \
     email=webmaster@example.com
 ```
 
+### DNS-Route53 Plugin
+
+Certbot's dns-route53 plugin uses the AWS Route53 API to prove
+ownership of the requested domain. Documentation for the plugin can be
+found at https://certbot-dns-route53.readthedocs.io/en/stable/. This
+plugin requires API credentials to be supplied either through the
+`aws-access-key-id` and `aws-secret-access-key` parameters on the
+`get-dns-route53-certificate` action, or from the
+`dns-route53-aws-access-key-id` and `dns-route63-aws-secret-access-key`
+settings in the charm configuration.
+
+To acquire a certificate using this plugin run a command like the
+following:
+
+```
+$ juju run-action --wait certbot/0 get-dns-route53-certificate \
+    agree-tos=true \
+    aws-access-key-id=ABCDEFGHIJKLMNOPQRST \
+    aws-secret-access-key=YcdqUfSGwvmIJAhjWNzGxSifdXr78RRqZrMnPxoz \    
+    domains=example.com \
+    email=webmaster@example.com
+```
+
 ## Integrating With Web-Servers
 
 ### HAProxy

--- a/actions.yaml
+++ b/actions.yaml
@@ -40,3 +40,54 @@ get-dns-google-certificate:
         provided the value of dns-google-propagation in the charm
         configuration will be used.
       type: integer
+
+get-dns-route53-certificate:
+  description: Acquire a certificate using the dns-google plugin.
+  params:
+    agree-tos:
+      description: |
+        Agree to the terms-of-service. If using Let's Encrypt these can
+        be found at https://letsencrypt.org/repository/. If this is not
+        provided the value of agree-tos in the charm configuration will
+        be used.
+      type: boolean
+    aws-access-key-id:
+      description: |
+        AWS_ACCESS_KEY_ID used to authenticate access to the DNS API.
+        For details please see
+        https://certbot-dns-route53.readthedocs.io/en/stable/#credentials.
+        If this is not provided the value of
+        dns-route53-aws-access-key-id in the charm configuration will be
+        used.
+      type: string
+    aws-secret-access-key:
+      description: |
+        AWS_SECRET_ACCESS_KEY used to authenticate access to the DNS
+        API. For details please see
+        https://certbot-dns-route53.readthedocs.io/en/stable/#credentials.
+        If this is not provided the value of
+        dns-route53-aws-secret-access-key in the charm configuration
+        will be used.
+      type: string
+    domains:
+      description: |
+        The domains to create the certificate for. This comma-separated
+        list contains all the domains to add to the certificate. The
+        first domain will be the subject of the certificate. Any
+        additional values will be added to the certificate as
+        alternative names. If this is not provided the value of domain
+        in the charm configuration will be used.
+      type: string
+    email:
+      description: |
+        Email address to register the certificates under. If this is not
+        provided the value of email in the charm configuration will be
+        used.
+      type: string
+    propagation-seconds:
+      description: |
+        The number of seconds to wait for DNS to propagate before asking
+        the ACME server to verify the DNS record. If this is not
+        provided the value of dns-google-propagation in the charm
+        configuration will be used.
+      type: integer

--- a/config.yaml
+++ b/config.yaml
@@ -40,6 +40,26 @@ options:
       The number of seconds to wait for DNS to propagate before asking
       the ACME server to verify the DNS record.
     type: int
+  dns-route53-aws-access-key-id:
+    default: ""
+    description: |
+      AWS_ACCESS_KEY_ID used by dns-route53 plugin to authenticate
+      access to the DNS API. For details please see
+      https://certbot-dns-route53.readthedocs.io/en/stable/#credentials
+    type: string
+  dns-route53-aws-secret-access-key:
+    default: ""
+    description: |
+      AWS_ACCESS_SECRET_KEY used by dns-route53 plugin to authenticate
+      access to the DNS API. For details please see
+      https://certbot-dns-route53.readthedocs.io/en/stable/#credentials
+    type: string
+  dns-route53-propagation-seconds:
+    default: 60
+    description: |
+      The number of seconds to wait for DNS to propagate before asking
+      the ACME server to verify the DNS record.
+    type: int
   domains:
     default: ""
     description: |
@@ -64,5 +84,6 @@ options:
     default: ""
     description: |
       The authenticator plugin to use to obtain (and renew) the
-      ceritificate. The currently supported plugins are dns-google. 
+      ceritificate. The currently supported plugins are dns-google &
+      dns-route53. 
     type: string


### PR DESCRIPTION
Add support of acquiring certificates using the dns-route53 plugin,
which uses the AWS route53 service to authenticate ownership of domains.