### PR TITLE
Allow certificate paths to refer to directories

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,5 +1,16 @@
 # Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
+deploy:
+  description: Run the post-renew deploy hook for a domain.
+  params:
+    domain:
+      description: |
+        Domain to run the deploy hook for, this must be the primary
+        domain on a certificate that has already been acquired by this
+        unit.
+      type: string
+    required: ["domain"]
+
 get-certificate:
   description: Acquire a certificate from an ACME service.
   params:

--- a/bin/deploy.py
+++ b/bin/deploy.py
@@ -5,34 +5,49 @@ import configparser
 import os
 import shutil
 import subprocess
+import sys
 
 
-def main():
-    config = configparser.ConfigParser()
-    config.read("/etc/certbot-charm/config.ini")
-    path = os.environ["RENEWED_LINEAGE"]
-    if config["deploy"]["cert-path"]:
-        shutil.copyfile(os.path.join(path, "cert.pem"), config["deploy"]["cert-path"])
-    if config["deploy"]["chain-path"]:
-        shutil.copyfile(os.path.join(path, "chain.pem"), config["deploy"]["chain-path"])
-    if config["deploy"]["combined-path"]:
-        with open(config["deploy"]["combined-path"], "wb") as outf:
-            with open(os.path.join(path, "fullchain.pem"), "rb") as inf:
-                shutil.copyfileobj(inf, outf)
-            with open(os.path.join(path, "privkey.pem"), "rb") as inf:
-                shutil.copyfileobj(inf, outf)
-    if config["deploy"]["fullchain-path"]:
-        shutil.copyfile(
-            os.path.join(path, "fullchain.pem"), config["deploy"]["fullchain-path"]
-        )
-    if config["deploy"]["key-path"]:
-        shutil.copyfile(os.path.join(path, "privkey.pem"), config["deploy"]["key-path"])
-    if config["deploy"]["command"]:
-        try:
-            subprocess.run(config["deploy"]["command"], shell=True)
-        except subprocess.CalledProcessError as err:
-            print("error running deploy command: ", err, file=os.stderr)
+class Deploy:
+    def __init__(self, path, configpath="/etc/certbot-charm/config.ini"):
+        super().__init__()
+        self._path = path
+        self._domain = os.path.basename(path)
+        self._config = configparser.ConfigParser()
+        self._config.read(configpath)
+
+    def run(self):
+        self._copy_file("cert.pem", "cert-path", ".crt")
+        self._copy_file("chain.pem", "chain-path", "_chain.pem")
+
+        dst = self._config["deploy"]["combined-path"]
+        if dst:
+            if os.path.isdir(dst):
+                dst = os.path.join(dst, self._domain + ".pem")
+            with open(dst, "wb") as outf:
+                with open(os.path.join(self._path, "fullchain.pem"), "rb") as inf:
+                    shutil.copyfileobj(inf, outf)
+                with open(os.path.join(self._path, "privkey.pem"), "rb") as inf:
+                    shutil.copyfileobj(inf, outf)
+
+        self._copy_file("fullchain.pem", "fullchain-path", "_fullchain.pem")
+        self._copy_file("privkey.pem", "key-path", ".key")
+
+        cmd = self._config["deploy"]["command"]
+        if cmd:
+            try:
+                subprocess.run(cmd, shell=True)
+            except subprocess.CalledProcessError as err:
+                print("error running deploy command: ", err, file=sys.stderr)
+
+    def _copy_file(self, srcfile, dstkey, suffix):
+        dst = self._config["deploy"].get(dstkey)
+        if not dst:
+            return
+        if os.path.isdir(dst):
+            dst = os.path.join(dst, self._domain + suffix)
+        shutil.copyfile(os.path.join(self._path, srcfile), dst)
 
 
 if __name__ == "__main__":
-    main()
+    Deploy(os.environ["RENEWED_LINEAGE"]).run()

--- a/config.yaml
+++ b/config.yaml
@@ -9,17 +9,25 @@ options:
     type: boolean
   cert-path:
     default: ""
-    description: Path to which the certificate will be copied.
+    description: |
+      Path to which the certificate will be copied. If this path is an
+      existing directory then the certificate will be copied into a file
+      named <domain>.crt in that directory.
     type: string
   chain-path:
     default: ""
-    description: Path to which the certificate chain will be copied.
+    description: |
+      Path to which the certificate chain will be copied. If this path
+      is an existing directory then the certificate chain will be copied
+      into a file named <domain>_chain.pem in that directory.
     type: string
   combined-path:
     default: ""
     description: |
       Path to which the combined full certificate chain and private key
-      will be copied.
+      will be copied. If this path is an existing directory then the
+      combined full certificate chain and key will be copied into a file
+      named <domain>.pem in that directory.
     type: string
   deploy-command:
     default: ""
@@ -62,11 +70,18 @@ options:
     type: string
   fullchain-path:
     default: ""
-    description: Path to which the full certificate chain will be copied.
+    description: |
+      Path to which the full certificate chain will be copied. If this
+      path is an existing directory then the full certificate chain will
+      be copied into a file named <domain>_fullchain.pem in that
+      directory.
     type: string
   key-path:
     default: ""
-    description: Path to which the private key will be copied.
+    description: |
+      Path to which the private key will be copied. If this path is an
+      existing directory then the private key will be copied into a file
+      named <domain>.key in that directory.
     type: string
   plugin:
     default: ""

--- a/run_tests
+++ b/run_tests
@@ -7,9 +7,9 @@ if [ -z "$VIRTUAL_ENV" -a -d venv/ ]; then
 fi
 
 if [ -z "$PYTHONPATH" ]; then
-    export PYTHONPATH=src
+    export PYTHONPATH=src:bin
 else
-    export PYTHONPATH="src:$PYTHONPATH"
+    export PYTHONPATH="src:bin:$PYTHONPATH"
 fi
 
 flake8

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -94,6 +94,17 @@ class TestCharm(unittest.TestCase):
         charm._host.unlink.assert_called_once_with(
             "/etc/letsencrypt/renewal-hooks/deploy/certbot-charm")
 
+    def test_deploy_action(self):
+        charm._host = Mock()
+        harness = Harness(charm.CertbotCharm)
+        self.addCleanup(harness.cleanup)
+        harness.begin()
+        event = Mock(params={"domain": "example.com"})
+        harness.charm._on_deploy_action(event)
+        charm._host.run.assert_called_once_with(
+            ["/etc/letsencrypt/renewal-hooks/deploy/certbot-charm"],
+            env={"RENEWED_LINEAGE": "/etc/letsencrypt/live/example.com"})
+
     def test_get_certificate_action_dns_google(self):
         os.environ["JUJU_ACTION_UUID"] = "1"
         charm._host = Mock()

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,149 @@
+# Copyright 2020 Canonical Ltd
+# See LICENSE file for licensing details.
+
+import configparser
+import os
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import Mock
+
+import deploy
+
+
+class TestDeploy(unittest.TestCase):
+    def test_copy_files(self):
+        with tempfile.TemporaryDirectory() as dir:
+            os.mkdir(os.path.join(dir, "example.com"))
+            os.mkdir(os.path.join(dir, "dest"))
+            configfile = os.path.join(dir, "config.ini")
+            certfile = os.path.join(dir, "example.com", "cert.pem")
+            chainfile = os.path.join(dir, "example.com", "chain.pem")
+            fullchainfile = os.path.join(dir, "example.com", "fullchain.pem")
+            keyfile = os.path.join(dir, "example.com", "privkey.pem")
+
+            config = configparser.ConfigParser()
+            config.add_section("deploy")
+            config["DEFAULT"]["cert-path"] = os.path.join(dir, "dest", "cert")
+            config["DEFAULT"]["chain-path"] = os.path.join(dir, "dest", "chain")
+            config["DEFAULT"]["combined-path"] = os.path.join(dir, "dest", "combined")
+            config["DEFAULT"]["fullchain-path"] = os.path.join(dir, "dest", "fullchain")
+            config["DEFAULT"]["key-path"] = os.path.join(dir, "dest", "key")
+            config["deploy"]["command"] = ""
+            with open(configfile, "w") as f:
+                config.write(f)
+
+            with open(certfile, "w") as f:
+                f.write("CERTIFICATE\n")
+            with open(chainfile, "w") as f:
+                f.write("CHAIN\n")
+            with open(fullchainfile, "w") as f:
+                f.write("FULLCHAIN\n")
+            with open(keyfile, "w") as f:
+                f.write("KEY\n")
+
+            d = deploy.Deploy(os.path.join(dir, "example.com"), configfile)
+            d.run()
+
+            with open(os.path.join(dir, "dest", "cert")) as f:
+                b = f.read()
+                self.assertEqual(b, "CERTIFICATE\n")
+            with open(os.path.join(dir, "dest", "chain")) as f:
+                b = f.read()
+                self.assertEqual(b, "CHAIN\n")
+            with open(os.path.join(dir, "dest", "combined")) as f:
+                b = f.read()
+                self.assertEqual(b, "FULLCHAIN\nKEY\n")
+            with open(os.path.join(dir, "dest", "fullchain")) as f:
+                b = f.read()
+                self.assertEqual(b, "FULLCHAIN\n")
+            with open(os.path.join(dir, "dest", "key")) as f:
+                b = f.read()
+                self.assertEqual(b, "KEY\n")
+
+    def test_copy_files_dir(self):
+        with tempfile.TemporaryDirectory() as dir:
+            os.mkdir(os.path.join(dir, "example.com"))
+            os.mkdir(os.path.join(dir, "dest"))
+            configfile = os.path.join(dir, "config.ini")
+            certfile = os.path.join(dir, "example.com", "cert.pem")
+            chainfile = os.path.join(dir, "example.com", "chain.pem")
+            fullchainfile = os.path.join(dir, "example.com", "fullchain.pem")
+            keyfile = os.path.join(dir, "example.com", "privkey.pem")
+
+            config = configparser.ConfigParser()
+            config.add_section("deploy")
+            config["DEFAULT"]["cert-path"] = os.path.join(dir, "dest")
+            config["DEFAULT"]["chain-path"] = os.path.join(dir, "dest")
+            config["DEFAULT"]["combined-path"] = os.path.join(dir, "dest")
+            config["DEFAULT"]["fullchain-path"] = os.path.join(dir, "dest")
+            config["DEFAULT"]["key-path"] = os.path.join(dir, "dest")
+            config["deploy"]["command"] = ""
+            with open(configfile, "w") as f:
+                config.write(f)
+
+            with open(certfile, "w") as f:
+                f.write("CERTIFICATE\n")
+            with open(chainfile, "w") as f:
+                f.write("CHAIN\n")
+            with open(fullchainfile, "w") as f:
+                f.write("FULLCHAIN\n")
+            with open(keyfile, "w") as f:
+                f.write("KEY\n")
+
+            d = deploy.Deploy(os.path.join(dir, "example.com"), configfile)
+            d.run()
+
+            with open(os.path.join(dir, "dest", "example.com.crt")) as f:
+                b = f.read()
+                self.assertEqual(b, "CERTIFICATE\n")
+            with open(os.path.join(dir, "dest", "example.com_chain.pem")) as f:
+                b = f.read()
+                self.assertEqual(b, "CHAIN\n")
+            with open(os.path.join(dir, "dest", "example.com.pem")) as f:
+                b = f.read()
+                self.assertEqual(b, "FULLCHAIN\nKEY\n")
+            with open(os.path.join(dir, "dest", "example.com_fullchain.pem")) as f:
+                b = f.read()
+                self.assertEqual(b, "FULLCHAIN\n")
+            with open(os.path.join(dir, "dest", "example.com.key")) as f:
+                b = f.read()
+                self.assertEqual(b, "KEY\n")
+
+    def test_deploy_command(self):
+        with tempfile.TemporaryDirectory() as dir:
+            configfile = os.path.join(dir, "config.ini")
+            config = configparser.ConfigParser()
+            config.add_section("deploy")
+            config["DEFAULT"]["cert-path"] = ""
+            config["DEFAULT"]["chain-path"] = ""
+            config["DEFAULT"]["combined-path"] = ""
+            config["DEFAULT"]["fullchain-path"] = ""
+            config["DEFAULT"]["key-path"] = ""
+            config["deploy"]["command"] = "echo 'OK!'"
+            with open(configfile, "w") as f:
+                config.write(f)
+
+            d = deploy.Deploy(os.path.join(dir, "example.com"), configfile)
+            subprocess.run = Mock()
+            d.run()
+            subprocess.run.assert_called_once_with("echo 'OK!'", shell=True)
+
+    def test_deploy_command_error(self):
+        with tempfile.TemporaryDirectory() as dir:
+            configfile = os.path.join(dir, "config.ini")
+            config = configparser.ConfigParser()
+            config.add_section("deploy")
+            config["DEFAULT"]["cert-path"] = ""
+            config["DEFAULT"]["chain-path"] = ""
+            config["DEFAULT"]["combined-path"] = ""
+            config["DEFAULT"]["fullchain-path"] = ""
+            config["DEFAULT"]["key-path"] = ""
+            config["deploy"]["command"] = "echo 'OK!'"
+            with open(configfile, "w") as f:
+                config.write(f)
+
+            d = deploy.Deploy(os.path.join(dir, "example.com"), configfile)
+            subprocess.run = Mock(side_effect=subprocess.CalledProcessError(1, "test"))
+            d.run()
+            subprocess.run.assert_called_once_with("echo 'OK!'", shell=True)


### PR DESCRIPTION
The paths that certificates are deployed to can now be directories. The
files will be be copied into those directories with well defined names.
Also enable running the deploy script as an action.