### PR TITLE
make a single get-certificate action

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,19 @@ Certbot's dns-google plugin uses the Google Cloud DNS API to prove
 ownership of the requested domain. Documentation for the plugin can be
 found at https://certbot-dns-google.readthedocs.io/en/stable/. This
 plugin requires API credentials to be supplied either through the
-`credentials` parameter on the `get-dns-google-certificate` action, or
-from the `dns-google-credentials` setting in the charm configuration.
+`credentials` parameter on the `get-certificate` action, or from the
+`dns-google-credentials` setting in the charm configuration.
 
 To acquire a certificate using this plugin run a command like the
 following:
 
 ```
-$ juju run-action --wait certbot/0 get-dns-google-certificate \
+$ juju run-action --wait certbot/0 get-certificate \
     agree-tos=true \
     credentials=`cat cred.json | base64 -w0` \
     domains=example.com \
-    email=webmaster@example.com
+    email=webmaster@example.com \
+    plugin=dns-google
 ```
 
 ### DNS-Route53 Plugin
@@ -39,20 +40,21 @@ ownership of the requested domain. Documentation for the plugin can be
 found at https://certbot-dns-route53.readthedocs.io/en/stable/. This
 plugin requires API credentials to be supplied either through the
 `aws-access-key-id` and `aws-secret-access-key` parameters on the
-`get-dns-route53-certificate` action, or from the
-`dns-route53-aws-access-key-id` and `dns-route63-aws-secret-access-key`
-settings in the charm configuration.
+`get-certificate` action, or from the `dns-route53-aws-access-key-id`
+and `dns-route63-aws-secret-access-key` settings in the charm
+configuration.
 
 To acquire a certificate using this plugin run a command like the
 following:
 
 ```
-$ juju run-action --wait certbot/0 get-dns-route53-certificate \
+$ juju run-action --wait certbot/0 get-certificate \
     agree-tos=true \
     aws-access-key-id=ABCDEFGHIJKLMNOPQRST \
     aws-secret-access-key=YcdqUfSGwvmIJAhjWNzGxSifdXr78RRqZrMnPxoz \    
     domains=example.com \
-    email=webmaster@example.com
+    email=webmaster@example.com \
+    plugin=dns-route53
 ```
 
 ## Integrating With Web-Servers

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,48 +1,7 @@
 # Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
-get-dns-google-certificate:
-  description: Acquire a certificate using the dns-google plugin.
-  params:
-    agree-tos:
-      description: |
-        Agree to the terms-of-service. If using Let's Encrypt these can
-        be found at https://letsencrypt.org/repository/. If this is not
-        provided the value of agree-tos in the charm configuration will
-        be used.
-      type: boolean    
-    credentials:
-      description: |
-        Base64 encoded credential file used by the dns-google plugin to
-        access the DNS system. For details of this file please see
-        https://certbot-dns-google.readthedocs.io/en/stable/#credentials.
-        If this is not provided the value of dns-google-credentials in
-        the charm configuration will be used.
-      type: string
-    domains:
-      description: |
-        The domains to create the certificate for. This comma-separated
-        list contains all the domains to add to the certificate. The
-        first domain will be the subject of the certificate. Any
-        additional values will be added to the certificate as
-        alternative names. If this is not provided the value of domain
-        in the charm configuration will be used.
-      type: string
-    email:
-      description: |
-        Email address to register the certificates under. If this is not
-        provided the value of email in the charm configuration will be
-        used.
-      type: string
-    propagation-seconds:
-      description: |
-        The number of seconds to wait for DNS to propagate before asking
-        the ACME server to verify the DNS record. If this is not
-        provided the value of dns-google-propagation in the charm
-        configuration will be used.
-      type: integer
-
-get-dns-route53-certificate:
-  description: Acquire a certificate using the dns-google plugin.
+get-certificate:
+  description: Acquire a certificate from an ACME service.
   params:
     agree-tos:
       description: |
@@ -53,8 +12,8 @@ get-dns-route53-certificate:
       type: boolean
     aws-access-key-id:
       description: |
-        AWS_ACCESS_KEY_ID used to authenticate access to the DNS API.
-        For details please see
+        AWS_ACCESS_KEY_ID used to authenticate access to the DNS API
+        when using the dns-route53 plugin. For details please see
         https://certbot-dns-route53.readthedocs.io/en/stable/#credentials.
         If this is not provided the value of
         dns-route53-aws-access-key-id in the charm configuration will be
@@ -63,11 +22,19 @@ get-dns-route53-certificate:
     aws-secret-access-key:
       description: |
         AWS_SECRET_ACCESS_KEY used to authenticate access to the DNS
-        API. For details please see
+        API when using the dns-route53 plugin. For details please see
         https://certbot-dns-route53.readthedocs.io/en/stable/#credentials.
         If this is not provided the value of
         dns-route53-aws-secret-access-key in the charm configuration
         will be used.
+      type: string
+    credentials:
+      description: |
+        Base64 encoded credential file used by the plugin to access the
+        DNS API. The contents of this file will be plugin-specific, see
+        the <plugin-name>-credentials fields in the charm configuration
+        for more details. If this is not specified then the
+        plugin-specific field in the charm configuration will be used.
       type: string
     domains:
       description: |
@@ -84,10 +51,16 @@ get-dns-route53-certificate:
         provided the value of email in the charm configuration will be
         used.
       type: string
+    plugin:
+      description: |
+        Name of the plugin to use to acquire the certificate. If this is
+        not specified then the value of plugin in the charm
+        configuration will be used.
+      type: string
     propagation-seconds:
       description: |
         The number of seconds to wait for DNS to propagate before asking
-        the ACME server to verify the DNS record. If this is not
-        provided the value of dns-google-propagation in the charm
-        configuration will be used.
+        the ACME server to verify the DNS record, if appropriate. If
+        this is not provided the value of propagation-seconds in the
+        charm configuration will be used.
       type: integer

--- a/config.yaml
+++ b/config.yaml
@@ -34,12 +34,6 @@ options:
       access the DNS system. For details of this file please see
       https://certbot-dns-google.readthedocs.io/en/stable/#credentials
     type: string
-  dns-google-propagation-seconds:
-    default: 60
-    description: |
-      The number of seconds to wait for DNS to propagate before asking
-      the ACME server to verify the DNS record.
-    type: int
   dns-route53-aws-access-key-id:
     default: ""
     description: |
@@ -54,12 +48,6 @@ options:
       access to the DNS API. For details please see
       https://certbot-dns-route53.readthedocs.io/en/stable/#credentials
     type: string
-  dns-route53-propagation-seconds:
-    default: 60
-    description: |
-      The number of seconds to wait for DNS to propagate before asking
-      the ACME server to verify the DNS record.
-    type: int
   domains:
     default: ""
     description: |
@@ -87,3 +75,9 @@ options:
       ceritificate. The currently supported plugins are dns-google &
       dns-route53. 
     type: string
+  propagation-seconds:
+    default: 60
+    description: |
+      The number of seconds to wait for DNS to propagate before asking
+      the ACME server to verify the DNS record.
+    type: int


### PR DESCRIPTION
Reduce the plugin-specific get-certificate actions to a single action.
This removes the potential for having a plethora of near-identical
actions in the charm.